### PR TITLE
Atd impliment basic comms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "stdio.h": "c",
     "i2c.h": "c",
     "gpio_types.h": "c",
-    "uart.h": "c"
+    "uart.h": "c",
+    "bme280.h": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "freertos.h": "c",
     "stdio.h": "c",
     "i2c.h": "c",
-    "gpio_types.h": "c"
+    "gpio_types.h": "c",
+    "uart.h": "c"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
     "board/esp32-wrover-kit-3.3v.cfg"
   ],
   "files.associations": {
-    "task.h": "c"
+    "task.h": "c",
+    "freertos.h": "c",
+    "stdio.h": "c",
+    "i2c.h": "c",
+    "gpio_types.h": "c"
   }
 }

--- a/README.md
+++ b/README.md
@@ -3,33 +3,21 @@
 | Supported Targets | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-S2 | ESP32-S3 |
 | ----------------- | ----- | -------- | -------- | -------- | -------- | -------- | -------- |
 
-(See the README.md file in the upper level 'examples' directory for more information about examples.)
-
-This is the simplest buildable example. The example is used by command `idf.py create-project`
-that copies the project to user specified path and set it's name. For more information follow the [docs page](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html#start-a-new-project)
-
-
-
-## How to use example
-We encourage the users to use the example as a template for the new projects.
-A recommended way is to follow the instructions on a [docs page](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html#start-a-new-project).
-
-## Example folder contents
-
-The project **sample_project** contains one source file in C language [main.c](main/main.c). The file is located in folder [main](main).
+## SD6-HARPS folder contents
 
 ESP-IDF projects are built using CMake. The project build configuration is contained in `CMakeLists.txt`
 files that provide set of directives and instructions describing the project's source files and targets
 (executable, library, or both). 
 
-Below is short explanation of remaining files in the project folder.
+Below is short explanation of the files in the project folder.
 
 ```
 ├── CMakeLists.txt
-├── main
+├── main/
 │   ├── CMakeLists.txt
 │   └── main.c
+│   └── peripherals/
+│   └── tasks/
+│   └── userHAL   
 └── README.md                  This is the file you are currently reading
 ```
-Additionally, the sample project contains Makefile and component.mk files, used for the legacy Make based build system. 
-They are not used or needed when building with CMake and idf.py.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Below is an explanation of the files in the project folder.
 ```
 ├── CMakeLists.txt
 ├── main/
-│   ├── CMakeLists.txt
+│   └── CMakeLists.txt
 │   └── main.c
 │   └── peripherals/
 │       └── bme280.c

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ESP-IDF projects are built using CMake. The project build configuration is conta
 files that provide set of directives and instructions describing the project's source files and targets
 (executable, library, or both). 
 
-Below is short explanation of the files in the project folder.
+Below is an explanation of the files in the project folder.
 
 ```
 ├── CMakeLists.txt
@@ -17,7 +17,15 @@ Below is short explanation of the files in the project folder.
 │   ├── CMakeLists.txt
 │   └── main.c
 │   └── peripherals/
+│       └── bme280.c
+│       └── bme280.h
 │   └── tasks/
-│   └── userHAL   
+│       └── basicTask.c
+│       └── pt-task.c
+│   └── userHAL/
+│       └── i2c.c
+│       └── i2c.h
+│       └── uart.c
+│       └── uart.h
 └── README.md                  This is the file you are currently reading
 ```

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,3 +1,7 @@
 idf_component_register(SRCS "main.c" 
+                        "peripherals/bme280.c"
                         "tasks/basicTask.c"
+                        "tasks/pt-task.c"
+                        "userHal/i2c.c"
+                        "userHal/uart.c"
                         INCLUDE_DIRS ".")

--- a/main/main.c
+++ b/main/main.c
@@ -4,6 +4,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "userHAL/i2c.h"
+#include "userHAL/uart.h"
 
 // External Dependencies
 extern void hello_task(void *pvParameter);
@@ -14,6 +15,14 @@ esp_err_t boardInit(void) {
     esp_err_t error = ESP_OK;
 
     error |= i2c_master_init();
+
+    error |= hal_master_init();
+
+    if (error != ESP_OK) {
+        printf("Error initializing board: %d\n", error);
+    } else {
+        printf("Board initialized successfully\n");
+    }
 
     return error;
 }

--- a/main/main.c
+++ b/main/main.c
@@ -3,12 +3,23 @@
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "userHAL/i2c.h"
 
 // External Dependencies
 extern void hello_task(void *pvParameter);
 
 // Declarations
 
+esp_err_t boardInit(void) {
+    esp_err_t error = ESP_OK;
+
+    error |= i2c_master_init();
+
+    return error;
+}
+
 void app_main(void) {
+    boardInit();
+
     xTaskCreate(&hello_task, "hello_task", 2048, NULL, 5, NULL);
 }

--- a/main/peripherals/bme280.c
+++ b/main/peripherals/bme280.c
@@ -4,3 +4,11 @@
 // External Dependencies
 
 // Declarations
+
+esp_err_t readFromBME(uint8_t *buffer, size_t size) {
+    return i2c_read_from_device(BME280_ADDRESS, buffer, size);
+}
+
+esp_err_t writeToBME(uint8_t *data, size_t size) {
+    return i2c_write_to_device(BME280_ADDRESS, data, size);
+}

--- a/main/peripherals/bme280.c
+++ b/main/peripherals/bme280.c
@@ -1,4 +1,5 @@
 // Includes
+#include "bme280.h"
 
 // External Dependencies
 

--- a/main/peripherals/bme280.c
+++ b/main/peripherals/bme280.c
@@ -1,0 +1,5 @@
+// Includes
+
+// External Dependencies
+
+// Declarations

--- a/main/peripherals/bme280.h
+++ b/main/peripherals/bme280.h
@@ -1,5 +1,39 @@
 // Includes
+#include <stdint.h>
+
+#include "userHAL/i2c.h"
 
 // External Dependencies
 
 // Declarations
+
+// The slave address of the bme280 is 0x77 when SD0 is connected to VDDIO, and 0x76 when SD0 is connected to GND
+// (figure out if we are connected to ground or not)
+#define BME280_ADDRESS 0b1110111
+
+struct registerMapBME {
+    uint8_t config;
+    uint8_t pressureMSB;
+    uint8_t pressureLSB;
+    uint8_t pressureXLSB;
+    uint8_t temperatureMSB;
+    uint8_t temperatureLSB;
+    uint8_t temperatureXLSB;
+    uint8_t humidityMSB;
+    uint8_t humidityLSB;
+};
+
+enum registerPointerValuesBME {
+    BME280_REGISTER_CONFIG = 0xF5,
+    BME280_REGISTER_PRESSURE_MSB = 0xF7,
+    BME280_REGISTER_PRESSURE_LSB = 0xF8,
+    BME280_REGISTER_PRESSURE_XLSB = 0xF9,
+    BME280_REGISTER_TEMPERATURE_MSB = 0xFA,
+    BME280_REGISTER_TEMPERATURE_LSB = 0xFB,
+    BME280_REGISTER_TEMPERATURE_XLSB = 0xFC,
+    BME280_REGISTER_HUMIDITY_MSB = 0xFD,
+    BME280_REGISTER_HUMIDITY_LSB = 0xFE
+};
+
+esp_err_t readFromBME(uint8_t *buffer, size_t size);
+esp_err_t writeToBME(uint8_t *data, size_t size);

--- a/main/peripherals/bme280.h
+++ b/main/peripherals/bme280.h
@@ -1,0 +1,5 @@
+// Includes
+
+// External Dependencies
+
+// Declarations

--- a/main/tasks/pt-task.c
+++ b/main/tasks/pt-task.c
@@ -8,10 +8,8 @@
 
 // Declarations
 
-static int num = 0;
-
-void hello_task(void *pvParameter) {
-    while (1) {
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
-    }
-}
+// void pt_task(void *pvParameter) {
+//     while (1) {
+//         vTaskDelay(1000 / portTICK_PERIOD_MS);
+//     }
+// }

--- a/main/tasks/pt-task.c
+++ b/main/tasks/pt-task.c
@@ -1,0 +1,17 @@
+// Includes
+#include <stdio.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+// External Dependencies
+
+// Declarations
+
+static int num = 0;
+
+void hello_task(void *pvParameter) {
+    while (1) {
+        vTaskDelay(1000 / portTICK_PERIOD_MS);
+    }
+}

--- a/main/userHAL/i2c.c
+++ b/main/userHAL/i2c.c
@@ -8,6 +8,7 @@
 #define DISABLE_MASTER_TX_BUFFER 0
 
 #define DEV_BOARD
+#define I2C_BUFFER_SIZE 1024
 
 esp_err_t i2c_master_init(void) {
     int i2c_master_port = I2C_NUM_0;
@@ -38,7 +39,8 @@ esp_err_t i2c_master_init(void) {
 }
 
 esp_err_t i2c_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size) {
-    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(data, size);
+    uint8_t i2cBuffer[I2C_BUFFER_SIZE];
+    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(i2cBuffer, I2C_BUFFER_SIZE);
 
     if (i2c_master_start(handle) == ESP_OK) {
         if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_WRITE, true) == ESP_OK) {
@@ -52,7 +54,8 @@ esp_err_t i2c_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size)
 }
 
 esp_err_t i2c_read_from_device(uint8_t deviceAddress, uint8_t *buffer, size_t size) {
-    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(buffer, size);
+    uint8_t i2cBuffer[I2C_BUFFER_SIZE];
+    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(i2cBuffer, I2C_BUFFER_SIZE);
 
     if (i2c_master_start(handle) == ESP_OK) {
         if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_READ, true) == ESP_OK) {

--- a/main/userHAL/i2c.c
+++ b/main/userHAL/i2c.c
@@ -37,34 +37,30 @@ esp_err_t i2c_master_init(void) {
     return i2c_driver_install(i2c_master_port, configuration.mode, DISABLE_MASTER_RX_BUFFER, DISABLE_MASTER_TX_BUFFER, 0);
 }
 
-esp_err_t i2c_master_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size) {
-    esp_err_t error = ESP_OK;
-
+esp_err_t i2c_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size) {
     i2c_cmd_handle_t handle = i2c_cmd_link_create_static(data, size);
 
     if (i2c_master_start(handle) == ESP_OK) {
         if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_WRITE, true) == ESP_OK) {
             if (i2c_master_write(handle, data, size, true) == ESP_OK) {
-                error = i2c_master_stop(handle);
+                return i2c_master_stop(handle);
             }
         }
     }
 
-    return error;
+    return ESP_FAIL;
 }
 
-esp_err_t i2c_master_read_from_device(uint8_t deviceAddress, uint8_t *buffer, size_t size) {
-    esp_err_t error = ESP_OK;
-
+esp_err_t i2c_read_from_device(uint8_t deviceAddress, uint8_t *buffer, size_t size) {
     i2c_cmd_handle_t handle = i2c_cmd_link_create_static(buffer, size);
 
     if (i2c_master_start(handle) == ESP_OK) {
         if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_READ, true) == ESP_OK) {
             if (i2c_master_read(handle, buffer, size, I2C_MASTER_LAST_NACK) == ESP_OK) {
-                error = i2c_master_stop(handle);
+                return i2c_master_stop(handle);
             }
         }
     }
 
-    return error;
+    return ESP_FAIL;
 }

--- a/main/userHAL/i2c.c
+++ b/main/userHAL/i2c.c
@@ -1,0 +1,38 @@
+// Includes
+#include "i2c.h"
+
+// External Dependencies
+
+// Declarations
+#define DISABLE_MASTER_RX_BUFFER 0
+#define DISABLE_MASTER_TX_BUFFER 0
+
+#define DEV_BOARD
+
+esp_err_t i2c_master_init(void) {
+    int i2c_master_port = I2C_NUM_0;
+
+#ifdef DEV_BOARD
+    i2c_config_t configuration = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = GPIO_NUM_21,
+        .scl_io_num = GPIO_NUM_22,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = 100000};
+#endif
+
+#ifdef PCB_BOARD
+    i2c_config_t configuration = {
+        .mode = I2C_MODE_MASTER,
+        .sda_io_num = GPIO_NUM_2,
+        .scl_io_num = GPIO_NUM_14,
+        .sda_pullup_en = GPIO_PULLUP_ENABLE,
+        .scl_pullup_en = GPIO_PULLUP_ENABLE,
+        .master.clk_speed = 100000};
+#endif
+
+    i2c_param_config(i2c_master_port, &configuration);
+
+    return i2c_driver_install(i2c_master_port, configuration.mode, DISABLE_MASTER_RX_BUFFER, DISABLE_MASTER_TX_BUFFER, 0);
+}

--- a/main/userHAL/i2c.c
+++ b/main/userHAL/i2c.c
@@ -36,3 +36,35 @@ esp_err_t i2c_master_init(void) {
 
     return i2c_driver_install(i2c_master_port, configuration.mode, DISABLE_MASTER_RX_BUFFER, DISABLE_MASTER_TX_BUFFER, 0);
 }
+
+esp_err_t i2c_master_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size) {
+    esp_err_t error = ESP_OK;
+
+    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(data, size);
+
+    if (i2c_master_start(handle) == ESP_OK) {
+        if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_WRITE, true) == ESP_OK) {
+            if (i2c_master_write(handle, data, size, true) == ESP_OK) {
+                error = i2c_master_stop(handle);
+            }
+        }
+    }
+
+    return error;
+}
+
+esp_err_t i2c_master_read_from_device(uint8_t deviceAddress, uint8_t *buffer, size_t size) {
+    esp_err_t error = ESP_OK;
+
+    i2c_cmd_handle_t handle = i2c_cmd_link_create_static(buffer, size);
+
+    if (i2c_master_start(handle) == ESP_OK) {
+        if (i2c_master_write_byte(handle, (deviceAddress << 1) | I2C_MASTER_READ, true) == ESP_OK) {
+            if (i2c_master_read(handle, buffer, size, I2C_MASTER_LAST_NACK) == ESP_OK) {
+                error = i2c_master_stop(handle);
+            }
+        }
+    }
+
+    return error;
+}

--- a/main/userHAL/i2c.h
+++ b/main/userHAL/i2c.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "driver/i2c.h"
+#include "esp_err.h"
 #include "hal/gpio_types.h"
 
 // External Dependencies
@@ -9,3 +10,5 @@
 // Declarations
 
 esp_err_t i2c_master_init(void);
+esp_err_t i2c_write_to_device(uint8_t deviceAddress, uint8_t *data, size_t size);
+esp_err_t i2c_read_from_device(uint8_t deviceAddress, uint8_t *buffer, size_t size);

--- a/main/userHAL/i2c.h
+++ b/main/userHAL/i2c.h
@@ -1,0 +1,11 @@
+// Includes
+#include <stdio.h>
+
+#include "driver/i2c.h"
+#include "hal/gpio_types.h"
+
+// External Dependencies
+
+// Declarations
+
+esp_err_t i2c_master_init(void);

--- a/main/userHAL/uart.c
+++ b/main/userHAL/uart.c
@@ -4,13 +4,14 @@
 // External Dependencies
 
 // Declarations
+#define SYSTEM_BAUD_RATE 115200
 
 esp_err_t hal_master_init(void) {
     esp_err_t error = ESP_OK;
     const uart_port_t uart_num = UART_NUM_0;
 
     uart_config_t configuration = {
-        .baud_rate = 115200,
+        .baud_rate = SYSTEM_BAUD_RATE,
         .data_bits = UART_DATA_8_BITS,
         .parity = UART_PARITY_DISABLE,
         .stop_bits = UART_STOP_BITS_1,

--- a/main/userHAL/uart.c
+++ b/main/userHAL/uart.c
@@ -5,6 +5,7 @@
 
 // Declarations
 #define SYSTEM_BAUD_RATE 115200
+#define READ_WAIT_TIME 250
 
 esp_err_t hal_master_init(void) {
     esp_err_t error = ESP_OK;
@@ -25,4 +26,12 @@ esp_err_t hal_master_init(void) {
     error |= uart_driver_install(uart_num, 2048, 2048, 0, NULL, 0);
 
     return error;
+}
+
+esp_err_t uart_write_to_line(uint8_t *data, size_t size) {
+    return uart_write_bytes(UART_NUM_0, (const char *)data, size);
+}
+
+esp_err_t uart_read_from_line(uint8_t *buffer, size_t size) {
+    return uart_read_bytes(UART_NUM_0, buffer, size, READ_WAIT_TIME);
 }

--- a/main/userHAL/uart.c
+++ b/main/userHAL/uart.c
@@ -1,0 +1,27 @@
+// Includes
+#include "uart.h"
+
+// External Dependencies
+
+// Declarations
+
+esp_err_t hal_master_init(void) {
+    esp_err_t error = ESP_OK;
+    const uart_port_t uart_num = UART_NUM_0;
+
+    uart_config_t configuration = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        .rx_flow_ctrl_thresh = 0};
+
+    error |= uart_param_config(uart_num, &configuration);
+
+    error |= uart_set_pin(uart_num, GPIO_NUM_1, GPIO_NUM_3, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+
+    error |= uart_driver_install(uart_num, 2048, 2048, 0, NULL, 0);
+
+    return error;
+}

--- a/main/userHAL/uart.h
+++ b/main/userHAL/uart.h
@@ -1,0 +1,11 @@
+// Includes
+#include <stdio.h>
+
+#include "driver/uart.h"
+#include "hal/gpio_types.h"
+
+// External Dependencies
+
+// Declarations
+
+esp_err_t hal_master_init(void);

--- a/main/userHAL/uart.h
+++ b/main/userHAL/uart.h
@@ -10,3 +10,5 @@
 // Declarations
 
 esp_err_t hal_master_init(void);
+esp_err_t uart_write_to_line(uint8_t *data, size_t size);
+esp_err_t uart_read_from_line(uint8_t *buffer, size_t size);

--- a/main/userHAL/uart.h
+++ b/main/userHAL/uart.h
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "driver/uart.h"
+#include "esp_err.h"
 #include "hal/gpio_types.h"
 
 // External Dependencies


### PR DESCRIPTION
WHAT
- Add logic for setting up i2c
- Add logic for reading & writing with i2c
- Add logic for setting up uart
- Add logic for reading & writing with uart
- Add basic logic for interacting with BME

WHY
- We need to get a baseline of code into the system for communication
- Code has not been tested due to not having equipment (will be tested and updated once hardware has been acquired)